### PR TITLE
Separate dialyzer target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ## DEPS = deps/foo deps/bar
 DEPS =
 
-all: compile eunit
+all: compile eunit dialyzer
 
 clean:
 	@rebar clean
@@ -12,6 +12,8 @@ distclean:
 
 compile: $(DEPS)
 	@rebar compile
+
+dialyzer:
 	@dialyzer -Wrace_conditions -Wunderspecs -r ebin
 
 $(DEPS):


### PR DESCRIPTION
Currently dialyzer is run as part of the compile target, however, I think it's better to move it to it's own target. So the list of targets for 'all' becomes the "standard": compile eunit dialyzer.
